### PR TITLE
Fix [headerPattern] pattern.js

### DIFF
--- a/rules/pattern.js
+++ b/rules/pattern.js
@@ -1,6 +1,6 @@
 module.exports = {
   parserOpts: {
-    headerPattern: /^(\w+) (?:(#\d+)(!)? )?(?:(\[.*?\]) )?(?:([^\[\]]*?)(?: - (.*)|:?))$/,
+    headerPattern: /^(\w+)(?: (#\d+))?(!)? (?:\[(.*?)\] )?(?:([^\[\]]*?)(?: - (\X*)|:?))$/,
     headerCorrespondence: ['type', 'ticket', 'breaking', 'scope', 'subject', 'description'],
     issuePrefixes: ['#']
   }


### PR DESCRIPTION
- Accept all unicode in message [6]
- Allow to place the breaking change flag right after type (`Fix! [asdasd] asdasd: ...`)
- Exclude square brackets from captured scope